### PR TITLE
fix: missing pull request validation checks

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -412,6 +412,12 @@ func (cli GithubClient) GetStatuses(pr *github.PullRequest) (Statuses, error) {
 		}
 
 		for _, s := range checkRuns.CheckRuns {
+			// map check run conclusion to status to simplify the validation
+			if s.GetConclusion() != "success" && s.GetConclusion() != "neutral" && s.GetConclusion() != "skipped" {
+				cli.logger.Debug("Check run %s has conclusion %s.", s.GetName(), s.GetConclusion())
+				statuses = append(statuses, &Status{Name: s.GetName(), State: s.GetConclusion()})
+				continue
+			}
 			statuses = append(statuses, &Status{Name: s.GetName(), State: s.GetStatus()})
 		}
 

--- a/pkg/github/testdata/remote_pull_request_check_runs-sha1.yaml
+++ b/pkg/github/testdata/remote_pull_request_check_runs-sha1.yaml
@@ -1,0 +1,12 @@
+- url: /repos/test-owner/test-repo/commits/sha1/check-runs
+  status: 200
+  body: |
+    {
+      "total_count": 1,
+      "check_runs": [
+        {
+          "status": "completed",
+          "conclusion": "failure"
+        }
+      ]
+    }

--- a/pkg/github/testdata/remote_pull_request_check_runs-sha2.yaml
+++ b/pkg/github/testdata/remote_pull_request_check_runs-sha2.yaml
@@ -1,0 +1,12 @@
+- url: /repos/test-owner/test-repo/commits/sha2/check-runs
+  status: 200
+  body: |
+    {
+      "total_count": 1,
+      "check_runs": [
+        {
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ]
+    }

--- a/pkg/github/testdata/remote_pull_request_status-sha1.yaml
+++ b/pkg/github/testdata/remote_pull_request_status-sha1.yaml
@@ -1,0 +1,8 @@
+- url: /repos/test-owner/test-repo/commits/sha1/status
+  status: 200
+  body: |
+    {
+      "state": "pending",
+      "statuses": [
+      ]
+    }

--- a/pkg/github/testdata/remote_pull_request_status-sha2.yaml
+++ b/pkg/github/testdata/remote_pull_request_status-sha2.yaml
@@ -1,0 +1,8 @@
+- url: /repos/test-owner/test-repo/commits/sha2/status
+  status: 200
+  body: |
+    {
+      "state": "pending",
+      "statuses": [
+      ]
+    }


### PR DESCRIPTION
The pull request validation checks have two attributes to validate if the checks are successful. The attributes are `conclusion` and `status`. (https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference)

This commit enhances the logic to check for the `conclusion` and `status` of the checks together. And only merge the pull request if both are successful.